### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "stable"
+cache:
+  yarn: true
+  directories:
+  - node_modules
+script:
+  - yarn run build

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Alessandro Cifani
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-typescript-boilerplate
+# react-typescript-boilerplate [![Build Status](https://travis-ci.com/acifani/react-typescript-boilerplate.svg?branch=master)](https://travis-ci.com/acifani/react-typescript-boilerplate)
 
 TODO:
 
@@ -10,5 +10,5 @@ TODO:
 - [x] TSLint
 - [x] Sass
 - [ ] Tests
-- [ ] Travis
+- [x] Travis
 - [ ] Live demo

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 type Props = {
   world: string


### PR DESCRIPTION
I've tried to add travis integration, but the build fails as you can see [here](https://travis-ci.com/neslinesli93/react-typescript-boilerplate/builds/87543539).
I think it has to do with the Node version used by Travis, which I specified as `stable` and it seems to translate into `v10.11.0` as you can see from the job log.
What version do you use to build this repo locally? Maybe you could just add a `.nvmrc` file that contains the node version, since travis is able to parse that file format